### PR TITLE
Add Subject to all plugin operations.

### DIFF
--- a/src/main/java/org/indigo/cdmi/WrappedStorageBackend.java
+++ b/src/main/java/org/indigo/cdmi/WrappedStorageBackend.java
@@ -13,6 +13,8 @@ import static java.util.Objects.requireNonNull;
 
 import org.indigo.cdmi.spi.StorageBackend;
 
+import javax.security.auth.Subject;
+
 import java.util.List;
 
 /**
@@ -26,17 +28,17 @@ public class WrappedStorageBackend implements StorageBackend {
   }
 
   @Override
-  public List<BackendCapability> getCapabilities() {
-    return inner.getCapabilities();
+  public List<BackendCapability> getCapabilities(Subject id) {
+    return inner.getCapabilities(id);
   }
 
   @Override
-  public void updateCdmiObject(String path, String capabilitiesUri) throws BackEndException {
-    inner.updateCdmiObject(path, capabilitiesUri);
+  public void updateCdmiObject(Subject id, String path, String capabilitiesUri) throws BackEndException {
+    inner.updateCdmiObject(id, path, capabilitiesUri);
   }
 
   @Override
-  public CdmiObjectStatus getCurrentStatus(String path) {
-    return inner.getCurrentStatus(path);
+  public CdmiObjectStatus getCurrentStatus(Subject id, String path) {
+    return inner.getCurrentStatus(id, path);
   }
 }

--- a/src/main/java/org/indigo/cdmi/spi/StorageBackend.java
+++ b/src/main/java/org/indigo/cdmi/spi/StorageBackend.java
@@ -1,9 +1,9 @@
 /*
  * Copyright 2016 Karlsruhe Institute of Technology (KIT)
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
@@ -13,42 +13,47 @@ import org.indigo.cdmi.BackEndException;
 import org.indigo.cdmi.BackendCapability;
 import org.indigo.cdmi.CdmiObjectStatus;
 
+import javax.security.auth.Subject;
+
 import java.util.List;
 
 public interface StorageBackend {
 
   /**
    * Provides the available capabilities of the back-end.
-   * 
+   *
    * Comment: More specifically, these are the capabilities corresponding to some specific quality
    * of service.
-   * 
+   *
+   * @param id The identity of the user making this request
    * @return a {@link List} of the provided {@link BackendCapability} capabilities
    */
-  List<BackendCapability> getCapabilities();
+  List<BackendCapability> getCapabilities(Subject id);
 
   /**
    * Starts a CDMI object transition to the specified capabilities URI.
-   * 
+   *
    * This operation
-   * 
+   *
    * Comment: There should be the possiblity for this method to throw an exception; e.g., to
    * indicate that the capabilitiesUri is not known/supported; the specific transition is not
    * supported; the user is not authorised to make this transition, the path does not exist, ... The
    * transition is performed by the implementing back-end
-   * 
+   *
+   * @param id The identity of the user making this request
    * @param path the path to the data object or container as it can be queried via the CDMI
    *        interface
    * @param capabilitiesUri the target capabilities URI
    */
-  void updateCdmiObject(String path, String capabilitiesUri) throws BackEndException;
+  void updateCdmiObject(Subject id, String path, String capabilitiesUri) throws BackEndException;
 
   /**
    * Gets the current status of the CDMI object, including transition status and monitored
    * attributes of the back-end, e.g. "cdmi_latency_provided", for the object specified by path.
-   * 
+   *
+   * @param id The identity of the user making this request
    * @param path the path of the data object or container
    * @return the {@link CdmiObjectStatus}
    */
-  CdmiObjectStatus getCurrentStatus(String path);
+  CdmiObjectStatus getCurrentStatus(Subject id, String path);
 }


### PR DESCRIPTION
Motivation:

The plugin may wish to make authorisation decisions based on the user's
identity.

Modification:

Add a Subject (from JAAS) as an argument to each method.  This allows
the front-end to include whichever principals identify the user.

Result:

The plugin is provided with user-identity information, so can choose
whether or not to accept a request.
