### PR TITLE
Add PermissionDenied and InvalidArguments exception

### DIFF
--- a/src/main/java/org/indigo/cdmi/InvalidArgumentBackEndException.java
+++ b/src/main/java/org/indigo/cdmi/InvalidArgumentBackEndException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 Deutsches Elektronen-Synchrotron (DESY)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.indigo.cdmi;
+
+/**
+ * Indicates that the supplied request cannot be satisfied with the supplied
+ * arguments.  Repeating the same request is (very unlikely) to succeed.
+ * Subsequent requests may succeed if the arguments are modified.
+ */
+public class InvalidArgumentBackEndException extends BackEndException
+{
+  private static final long serialVersionUID = 1L;
+
+  public InvalidArgumentBackEndException() {
+    super();
+  }
+
+  public InvalidArgumentBackEndException(String message) {
+    super(message);
+  }
+
+  public InvalidArgumentBackEndException(Throwable cause) {
+    super(cause);
+  }
+
+  public InvalidArgumentBackEndException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/org/indigo/cdmi/PermissionDeniedBackEndException.java
+++ b/src/main/java/org/indigo/cdmi/PermissionDeniedBackEndException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 Deutsches Elektronen-Synchrotron (DESY)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.indigo.cdmi;
+
+/**
+ * This exception indicates that a user made a requested for which that user is
+ * not authorised.  That user reissuing the request will (very likely) yield the
+ * same result.  A different user issuing this request may succeed.
+ */
+public class PermissionDeniedBackEndException extends BackEndException
+{
+  private static final long serialVersionUID = 1L;
+
+  public PermissionDeniedBackEndException() {
+    super();
+  }
+
+  public PermissionDeniedBackEndException(String message) {
+    super(message);
+  }
+
+  public PermissionDeniedBackEndException(Throwable cause) {
+    super(cause);
+  }
+
+  public PermissionDeniedBackEndException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}


### PR DESCRIPTION
Motivation:

Users may attempt some activity for which they are not authorised.  The
CDMI server should repond differently, depending on a generic bad
request and a permission denied.

Modification:

Introduce a new BackEndException to describe an authorisation failure;
an InvalidArgumentBackEndException is introduced to describe failures
due to poor arguments.

Result:

CDMI server is able to distinguish between a bad request and permission
denied.
