### PR TITLE
Add support for discovering the users identity

### DIFF
--- a/src/main/java/org/indigo/cdmi/SubjectBasedStorageBackend.java
+++ b/src/main/java/org/indigo/cdmi/SubjectBasedStorageBackend.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2016 Deutsches Elektronen-Synchrotron (DESY)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.indigo.cdmi;
+
+import org.indigo.cdmi.spi.StorageBackend;
+
+import javax.security.auth.Subject;
+
+import java.security.PrivilegedAction;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.List;
+
+/**
+ * JAAS provides a standard mechanism to hold information about a logged in
+ * user: the Subject class.  This class wraps an existing StorageBackend and
+ * provides information about the logged in user.
+ * <p>
+ * This class is not thread safe, in particular, the caller is responsible for
+ * ensuring a happens-before relationship between {@code #setSubject} and any
+ * subsequent call to a StorageBackend method.
+ */
+public class SubjectBasedStorageBackend extends WrappedStorageBackend
+{
+  private Subject subject;
+
+  public SubjectBasedStorageBackend(StorageBackend inner) {
+    super(inner);
+  }
+
+  /**
+   * Specify the subject for subsequent operations.
+   * @param subject the identity of the user.
+   */
+  public void setSubject(Subject subject)
+  {
+    if (subject == null || subject.isReadOnly()) {
+        this.subject = subject;
+    } else {
+        this.subject = new Subject();
+        this.subject.getPrincipals().addAll(subject.getPrincipals());
+        this.subject.getPublicCredentials().addAll(subject.getPublicCredentials());
+        this.subject.getPrivateCredentials().addAll(subject.getPrivateCredentials());
+        this.subject.setReadOnly();
+    }
+  }
+
+  @Override
+  public List<BackendCapability> getCapabilities() {
+    return Subject.doAs(subject, (PrivilegedAction<List<BackendCapability>>) super::getCapabilities);
+  }
+
+  @Override
+  public void updateCdmiObject(String path, String capabilitiesUri) throws BackEndException {
+    try {
+        Subject.doAs(subject, (PrivilegedExceptionAction<Void>) () -> {
+            super.updateCdmiObject(path, capabilitiesUri);
+            return null;});
+    } catch (PrivilegedActionException e) {
+        Throwable t = e.getCause();
+        if (t instanceof BackEndException) {
+            throw (BackEndException) t;
+        }
+        if (t instanceof RuntimeException) {
+            throw (RuntimeException) t;
+        }
+        if (t instanceof Error) {
+            throw (Error) t;
+        }
+        throw new RuntimeException("Received unexpected exception: " + t.toString(), t);
+    } catch (RuntimeException | Error e) {
+        throw e;
+    }
+  }
+
+  @Override
+  public CdmiObjectStatus getCurrentStatus(String path) {
+      return Subject.doAs(subject, (PrivilegedAction<CdmiObjectStatus>) () -> {return super.getCurrentStatus(path);});
+  }
+}


### PR DESCRIPTION
Motivation:

The plugin is responsible for authorisation decisions.  To achieve this,
it needs to know who is the user.

Modification:

Add support for providing the user's identity.  This is achieved using
the concepts from JAAS: a Subject is provided as a thread-local value
that the plugin can discover as necessary.  Information about the user
is available as principals (such as the username) or as public
credentials (such as OIDC token).

Result:

The plugin should have sufficient information about the user to make
authorisation decisions.
