### PR TITLE
Add missing exception from StorageBackend methods

### DIFF
--- a/src/main/java/org/indigo/cdmi/WrappedStorageBackend.java
+++ b/src/main/java/org/indigo/cdmi/WrappedStorageBackend.java
@@ -26,7 +26,7 @@ public class WrappedStorageBackend implements StorageBackend {
   }
 
   @Override
-  public List<BackendCapability> getCapabilities() {
+  public List<BackendCapability> getCapabilities() throws BackEndException {
     return inner.getCapabilities();
   }
 
@@ -37,7 +37,7 @@ public class WrappedStorageBackend implements StorageBackend {
   }
 
   @Override
-  public CdmiObjectStatus getCurrentStatus(String path) {
+  public CdmiObjectStatus getCurrentStatus(String path) throws BackEndException {
     return inner.getCurrentStatus(path);
   }
 }

--- a/src/main/java/org/indigo/cdmi/spi/StorageBackend.java
+++ b/src/main/java/org/indigo/cdmi/spi/StorageBackend.java
@@ -1,9 +1,9 @@
 /*
  * Copyright 2016 Karlsruhe Institute of Technology (KIT)
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
@@ -19,24 +19,24 @@ public interface StorageBackend {
 
   /**
    * Provides the available capabilities of the back-end.
-   * 
+   *
    * Comment: More specifically, these are the capabilities corresponding to some specific quality
    * of service.
-   * 
+   *
    * @return a {@link List} of the provided {@link BackendCapability} capabilities
    */
-  List<BackendCapability> getCapabilities();
+  List<BackendCapability> getCapabilities() throws BackEndException;
 
   /**
    * Starts a CDMI object transition to the specified capabilities URI.
-   * 
+   *
    * This operation
-   * 
+   *
    * Comment: There should be the possiblity for this method to throw an exception; e.g., to
    * indicate that the capabilitiesUri is not known/supported; the specific transition is not
    * supported; the user is not authorised to make this transition, the path does not exist, ... The
    * transition is performed by the implementing back-end
-   * 
+   *
    * @param path the path to the data object or container as it can be queried via the CDMI
    *        interface
    * @param currentCapabilitiesUri the target capabilities URI
@@ -48,9 +48,9 @@ public interface StorageBackend {
   /**
    * Gets the current status of the CDMI object, including transition status and monitored
    * attributes of the back-end, e.g. "cdmi_latency_provided", for the object specified by path.
-   * 
+   *
    * @param path the path of the data object or container
    * @return the {@link CdmiObjectStatus}
    */
-  CdmiObjectStatus getCurrentStatus(String path);
+  CdmiObjectStatus getCurrentStatus(String path) throws BackEndException;
 }


### PR DESCRIPTION
Motivation:

In general, all queries to a plugin may fail; for example, the plugin
may loose connection with the backend system, or a user is not
authorised for any activity or discovering anything about the current
state of the backend system.

Modification:

Add exceptions to getCapabilities and getCurrentStatus methods.
Related classes are updated accordingly.

Result:

All methods provide the plugin with the possibility to report that the
operation failed.
